### PR TITLE
include null values in output if allownull is true

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -50,12 +50,14 @@ Schema.prototype.validate = function(data, opts) {
       value = rules.create(params[i], schema).apply(get(params[i]));
 
       // does this rule contain embedded schemas
-      if (typeof(schema.schema) == "object" && 
-          !_.isArray(schema.schema) && 
-          _.keys(schema.schema).length && 
+      if (typeof(schema.schema) == "object" &&
+          !_.isArray(schema.schema) &&
+          _.keys(schema.schema).length &&
           !_.isUndefined(value)) {
 
-        if(!(schema.allownull && _.isNull(value))) {
+        if(schema.allownull && _.isNull(value)) {
+          values[params[i]] = null;
+        } else {
           if (schema.type == "object") {
             var results = (new Schema(schema.schema)).validate(value);
             if(!results.valid) {

--- a/test/allownull.js
+++ b/test/allownull.js
@@ -1,0 +1,38 @@
+/*jshint expr:true*/
+var schemajs   = (typeof window === 'undefined') ? require('../schema') : window.schema;
+var expect     = (typeof window === 'undefined') ? require('chai').expect : window.chai.expect;
+
+describe("allownull schemas", function() {
+
+  var schema = schemajs.create({
+    input: {type: 'string', allownull: true}
+  });
+
+  it("should allow an attribute to be set to it's type", function() {
+    var form = schema.validate({input: 'username'});
+
+    expect(form.valid).to.be.ok;
+    expect(form.data.input).to.equal('username');
+  });
+
+  it("should allow an attribute to be set to null", function() {
+    var form = schema.validate({input: null});
+
+    expect(form.valid).to.be.ok;
+    expect(form.data.input).to.equal(null);
+  });
+
+  it("should be valid but not include an attribute if it is not included", function() {
+    var form = schema.validate({});
+
+    expect(form.valid).to.be.ok;
+    expect(form.data.input).to.eql(undefined);
+  });
+
+  it("should not validate if the attribute is a number", function() {
+    var form = schema.validate({input: 6});
+    expect(form.valid).to.not.be.ok;
+  });
+
+
+});

--- a/test/complex.js
+++ b/test/complex.js
@@ -8,7 +8,7 @@ describe("complex schemas", function()
    {
       var schema = schemajs.create(
       {
-          input: 
+          input:
           {
             type:'array',
             schema:
@@ -20,7 +20,7 @@ describe("complex schemas", function()
 
       var schema2 = schemajs.create(
       {
-          input: 
+          input:
           {
             type:'array',
             schema:
@@ -30,27 +30,30 @@ describe("complex schemas", function()
             allownull: true
           }
       });
-      
+
       var input1 = schema.validate({input: 'username'});
       var input2 = schema.validate({input: [112390123]});
       var input3 = schema.validate({input: [112390123, 'username']});
       var input4 = schema.validate({});
       var input5 = schema.validate({input: null});
       var input6 = schema2.validate({input: null});
-  
-      expect(!input1.valid).to.be.ok;
+
+      expect(input1.valid).to.not.be.ok;
       expect(input2.valid).to.be.ok;
-      expect(!input3.valid).to.be.ok;
+      expect(input2.data.input).to.eql([112390123]);
+      expect(input3.valid).to.not.be.ok;
       expect(input4.valid).to.be.ok;
-      expect(!input5.valid).to.be.ok;
+      expect(input5.valid).to.not.be.ok;
       expect(input6.valid).to.be.ok;
+      expect(input6.data.input).to.equal(null);
+
    });
 
    it("arrays and objects", function()
    {
       var schema = schemajs.create(
       {
-          input: 
+          input:
           {
             type:'array',
             schema:
@@ -63,13 +66,13 @@ describe("complex schemas", function()
             }
           }
       });
-      
+
       var input1 = schema.validate({input: 'laksjdf'});
       var input2 = schema.validate({input: [{label:"hi", num:5}, {label:"bye", num:0}]});
       var input3 = schema.validate({input: [{label:"hi", num:5}, {label:0, num:0}]});
       var input4 = schema.validate({input: [{label:"hi", num:5}, "oops"]});
       var input5 = schema.validate({});
-   
+
 
       expect(!input1.valid).to.be.ok;
       expect(input2.valid).to.be.ok;
@@ -78,12 +81,12 @@ describe("complex schemas", function()
       expect(input5.valid).to.be.ok;
    });
 
-   
+
    it("testing complex object type", function()
    {
       var schema = schemajs.create(
       {
-          input: 
+          input:
           {
             type:'object',
             schema:
@@ -96,7 +99,7 @@ describe("complex schemas", function()
 
       var schema2 = schemajs.create(
       {
-          input: 
+          input:
           {
             type:'object',
             schema:
@@ -107,7 +110,7 @@ describe("complex schemas", function()
             allownull: true
           }
       });
-      
+
       var input1 = schema.validate({input: 'username'});
       var input2 = schema.validate({input: {name:"x", email:"x@xyz.com"}});
       var input3 = schema.validate({input: {name:123, email:"x@xyz.com"}});
@@ -115,11 +118,11 @@ describe("complex schemas", function()
       var input5 = schema.validate({input:null});
       var input6 = schema2.validate({input:null});
 
-      expect(!input1.valid).to.be.ok;
+      expect(input1.valid).to.not.be.ok;
       expect(input2.valid).to.be.ok;
       expect(input2.valid).to.be.ok;
       expect(input4.valid).to.be.ok;
-      expect(!input5.valid).to.be.ok;
+      expect(input5.valid).to.not.be.ok;
       expect(input6.valid).to.be.ok;
    });
 });

--- a/test/required.js
+++ b/test/required.js
@@ -13,7 +13,7 @@ describe("required schemas", function()
       });
       var input1 = schema.validate({input: 'username'});
       var input2 = schema.validate({});
-   
+
       expect(input1.valid).to.be.ok;
       expect(!input2.valid).to.be.ok;
    });
@@ -29,9 +29,11 @@ describe("required schemas", function()
       var input1 = schema.validate({input: 'username'});
       var input2 = schema.validate({});
       var input3 = schema.validate({input:null, output:"hi there"});
-  
+
       expect(input1.valid).to.be.ok;
+      expect(input1.data.input).to.equal('username');
       expect(!input2.valid).to.be.ok;
       expect(input3.valid).to.be.ok;
+      expect(input3.data.input).to.equal(null);
    });
 });


### PR DESCRIPTION
Been using this library quite a lot, thanks!

This PR aims to make the output of null values more consistent with the input data. Namely if the input has a value set to `null` then the output value should remain as `null` if `allownull` is set to true.

Previously it would strip out the key/value completely if the value was null, even if allownull was set to true.

Apologies for the whitespace strip - my editor loves doing that.
